### PR TITLE
Change remote_api default port to 8880 and bump to Alpine 3.24

### DIFF
--- a/remote_api/CHANGELOG.md
+++ b/remote_api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+- Change default host port to 8880 to avoid conflicts with port 80
+- Upgrade base image to Alpine 3.24
+
 ## 1.3.0
 
 - Upgrade base image to alpine 3.19

--- a/remote_api/build.yaml
+++ b/remote_api/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.24
+  amd64: ghcr.io/home-assistant/amd64-base:3.24

--- a/remote_api/config.yaml
+++ b/remote_api/config.yaml
@@ -1,5 +1,5 @@
 name: Remote API proxy
-version: 1.3.0
+version: 1.4.0
 slug: remote_api
 description: Remote API proxy for Home Assistant
 url: https://developers.home-assistant.io/docs/supervisor/development/#supervisor-api-access
@@ -12,7 +12,7 @@ boot: manual
 hassio_api: true
 hassio_role: admin
 ports:
-  80/tcp: 80
+  80/tcp: 8880
 options: {}
 schema: false
 image: homeassistant/{arch}-addon-dev-remote_api


### PR DESCRIPTION
## Summary

- Change the default host port mapping of the Remote API proxy addon from 80 to 8880 to avoid conflicts with other services commonly using port 80. The container still listens on port 80 internally, so the socat proxy setup is unchanged and the port remains remappable in the addon UI.
- Upgrade the base images to Alpine 3.24 (the version the current `docker-base` builds on).
- Bump the addon version to 1.4.0 and add a changelog entry.

Note: the recent Supervisor unix socket changes only affect Supervisor→Core communication; the Supervisor API consumed by this addon still listens on TCP port 80, so the proxy keeps working as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)