### PR TITLE
Pin home-assistant/builder to 2026.02.1

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@4de35182ce1e329181bffcbcc84d33db5e2c7e10 # 2026.06.0
+        uses: home-assistant/builder@6cb4fd3d1338b6e22d0958a4bcb53e0965ea63b4 # 2026.02.1
         with:
           image: ${{ matrix.arch }}
           args: |


### PR DESCRIPTION
## Summary

CI builds currently fail with:

```
docker pull ghcr.io/home-assistant/amd64-builder:4de35182ce1e329181bffcbcc84d33db5e2c7e10
Error response from daemon: manifest unknown
```

The builder action resolves its container image tag from the ref it is invoked with (last path component of `github.action_path`), so a SHA pin only works when the release CI also published a builder image tagged with that commit SHA. That is the case for 2026.02.1 (`6cb4fd3d`, the pin used in [home-assistant/addons](https://github.com/home-assistant/addons/blob/master/.github/workflows/builder.yml)), but not for 2026.06.0 (`4de35182`) — releases after 2026.02.1 no longer ship the legacy builder image at all, only the new reusable actions.

This pins the same 2026.02.1 SHA as home-assistant/addons. Longer term, the workflow should be migrated to the new reusable actions (`prepare-multi-arch-matrix`/`build-image`/`publish-multi-arch-manifest`), since the legacy builder image is deprecated and frozen at 2026.02.1. Until then, Dependabot bumps of this action will re-break the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)